### PR TITLE
refactor: enable esm / cjs hybrid exports with rollup (Flat Config - part 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,24 +12,36 @@
     "email": "maiko.tan.coding@gmail.com"
   },
   "license": "CC-BY-NC-4.0",
-  "type": "commonjs",
+  "type": "module",
   "files": [
     "dist"
   ],
   "exports": {
     ".": {
-      "require": "./dist/index.js"
+      "types": {
+        "import": "./dist/index.d.ts"
+      },
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     },
     "./node": {
-      "require": "./dist/node.js"
+      "types": {
+        "import": "./dist/node.d.ts"
+      },
+      "import": "./dist/node.js",
+      "require": "./dist/node.cjs"
     },
     "./typescript": {
-      "require": "./dist/typescript.js"
+      "types": {
+        "import": "./dist/typescript.d.ts"
+      },
+      "import": "./dist/typescript.js",
+      "require": "./dist/typescript.cjs"
     },
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc"
+    "build": "rollup -c rollup.config.ts --configPlugin @rollup/plugin-typescript"
   },
   "prettier": "@hamster-bot/prettier-config",
   "eslintConfig": {
@@ -42,6 +54,9 @@
   },
   "devDependencies": {
     "@hamster-bot/prettier-config": "*",
+    "@rollup/plugin-commonjs": "^25.0.8",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-typescript": "^11.1.6",
     "@types/eslint": "^8.56.10",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "@typescript-eslint/parser": "^7.1.0",
@@ -51,6 +66,8 @@
     "eslint-plugin-mocha": "^10.3.0",
     "eslint-plugin-n": "^17.3.1",
     "eslint-plugin-promise": "^6.1.0",
+    "rollup": "^4.18.0",
+    "tslib": "^2.6.2",
     "typescript": "^5.3.3"
   },
   "peerDependencies": {

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,0 +1,29 @@
+import typescript from '@rollup/plugin-typescript'
+import commonjs from '@rollup/plugin-commonjs'
+import nodeResolve from '@rollup/plugin-node-resolve'
+import { defineConfig } from 'rollup'
+
+export default defineConfig({
+  input: [
+    'src/index.ts',
+    'src/node.ts',
+    'src/typescript.ts',
+  ],
+  output: [
+    {
+      dir: 'dist',
+      format: 'cjs',
+      entryFileNames(chunkInfo) {
+        return chunkInfo.name + '.cjs'
+      },
+    },
+    {
+      dir: 'dist',
+      format: 'esm',
+      entryFileNames(chunkInfo) {
+        return chunkInfo.name + '.js'
+      },
+    },
+  ],
+  plugins: [nodeResolve(), commonjs(), typescript()],
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Linter } from 'eslint'
 
-export = {
+export default {
   extends: ['standard', 'plugin:import/recommended'],
   settings: {
     'import/resolver': {
@@ -58,4 +58,4 @@ export = {
       },
     ],
   },
-} satisfies Linter.Config
+} satisfies Linter.Config as Linter.Config

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,6 +1,6 @@
 import { Linter } from 'eslint'
 
-export = {
+export default {
   extends: ['./index.js', 'plugin:n/recommended'],
   env: {
     node: true,
@@ -23,4 +23,4 @@ export = {
     'n/prefer-global/url-search-params': 'error',
     'n/prefer-global/url': 'error',
   },
-} satisfies Linter.Config
+} satisfies Linter.Config as Linter.Config

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -1,6 +1,6 @@
 import { Linter } from 'eslint'
 
-export = {
+export default {
   extends: ['./index.js', 'plugin:@typescript-eslint/recommended', 'plugin:import/typescript'],
   parser: '@typescript-eslint/parser',
   settings: {
@@ -57,4 +57,4 @@ export = {
     ],
     '@typescript-eslint/type-annotation-spacing': 'error',
   },
-} satisfies Linter.Config
+} satisfies Linter.Config as Linter.Config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "CommonJS",
+    "target": "ESNext",
+    "module": "ESNext",
     "rootDir": "./src",
     "outDir": "./dist",
     "declaration": true,
-  }
+    "esModuleInterop": true,
+    "moduleResolution": "Bundler"
+  },
+  "references": [{ "path": "./tsconfig.node.json" }],
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "composite": true,
+    "esModuleInterop": true,
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true,
+  },
+  "include": [
+    "rollup.config.ts",
+  ],
+}


### PR DESCRIPTION
This is the part 2 of the supporting for Flat Config introduced by ESLint v8.21.0 and enabled by default in ESLint v9 and later.

This commit would export the config object in both ESM and CJS format, also the types so then users could use typescript to check type errors in their flat config.