### PR TITLE
feat: migrate to flat config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,33 +15,37 @@ yarn add --dev eslint @hamster-bot/eslint-config
 If you are using TypeScript as well, you need to install `typescript-eslint` plugin and `eslint-import-resolver-typescript`.
 
 ```bash
-npm i --save-dev @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-typescript
+npm i --save-dev typescript-eslint eslint-import-resolver-typescript
 # Or use yarn
-yarn add --dev @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-import-resolver-typescript
+yarn add --dev typescript-eslint eslint-import-resolver-typescript
 ```
 
 ## Usage
 
-Create an eslint configuration file like `.eslintrc.json` and append the following:
+This package provides flat config introduced in ESLint v9.
 
-```json
-{
-  "extends": [
-    "@hamster-bot"
-  ]
-}
+Create an eslint configuration file like `eslint.config.js` and append the following:
+
+```js
+const hamster = require('@hamster-bot/eslint-config')
+
+module.exports = [
+  hamster,
+  // Add more configurations here
+]
 ```
 
 ------
 
 TypeScript user should use `@hamster-bot/eslint-config/typescript`:
 
-```json
-{
-  "extends": [
-    "@hamster-bot/eslint-config/typescript"
-  ]
-}
+```js
+const hamster = require('@hamster-bot/eslint-config/typescript')
+
+module.exports = [
+  hamster,
+  // Add more configurations here
+]
 ```
 
 ## License

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,3 @@
+import configs from './dist/index.js'
+
+export default configs

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     ]
   },
   "dependencies": {
+    "@eslint/eslintrc": "^3.1.0",
     "eslint-config-standard": "^17.1.0"
   },
   "devDependencies": {
@@ -59,22 +60,23 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/eslint": "^8.56.10",
-    "@typescript-eslint/eslint-plugin": "^7.1.0",
-    "@typescript-eslint/parser": "^7.1.0",
-    "eslint": "^8.57.0",
+    "@types/eslint__eslintrc": "^2.1.1",
+    "eslint": ">=9",
     "eslint-import-resolver-typescript": "^3.6.1",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-mocha": "^10.3.0",
-    "eslint-plugin-n": "^17.3.1",
-    "eslint-plugin-promise": "^6.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-mocha": "^10.4.3",
+    "eslint-plugin-n": "^17.7.0",
+    "eslint-plugin-promise": "^6.2.0",
+    "globals": "^15.3.0",
     "rollup": "^4.18.0",
     "tslib": "^2.6.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "typescript-eslint": "^7.12.0"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
-    "eslint": "^8.57.0",
+    "eslint": ">=9",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-mocha": "^10.3.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@hamster-bot/prettier-config": "*",
-    "@rollup/plugin-commonjs": "^25.0.8",
+    "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/eslint": "^8.56.10",
@@ -72,13 +72,13 @@
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-mocha": "^10.4.3",
-    "eslint-plugin-n": "^17.7.0",
-    "eslint-plugin-promise": "^6.2.0",
-    "globals": "^15.3.0",
+    "eslint-plugin-n": "^17.9.0",
+    "eslint-plugin-promise": "^6.4.0",
+    "globals": "^15.8.0",
     "rollup": "^4.18.0",
-    "tslib": "^2.6.2",
-    "typescript": "^5.3.3",
-    "typescript-eslint": "^7.12.0"
+    "tslib": "^2.6.3",
+    "typescript": "^5.5.3",
+    "typescript-eslint": "^7.15.0"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -4,11 +4,7 @@ import nodeResolve from '@rollup/plugin-node-resolve'
 import { defineConfig } from 'rollup'
 
 export default defineConfig({
-  input: [
-    'src/index.ts',
-    'src/node.ts',
-    'src/typescript.ts',
-  ],
+  input: ['src/index.ts', 'src/node.ts', 'src/typescript.ts'],
   output: [
     {
       dir: 'dist',
@@ -25,5 +21,15 @@ export default defineConfig({
       },
     },
   ],
+  external: [
+    '@eslint/eslintrc',
+    'eslint',
+    'eslint-plugin-import',
+    'eslint-plugin-mocha',
+    'eslint-config-standard',
+    'globals',
+    'typescript-eslint',
+  ],
+  treeshake: true,
   plugins: [nodeResolve(), commonjs(), typescript()],
 })

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,36 @@
+declare module 'eslint-config-standard' {
+import { Linter } from 'eslint'
+  const config: Linter.Config
+  export = config
+}
+
+declare module 'eslint-plugin-import' {
+  import { Linter } from 'eslint'
+  const _config: {
+    rules: Linter.RulesRecord
+    configs: {
+      recommended: Linter.Config
+      errors: Linter.Config
+      warnings: Linter.Config
+      react: Linter.Config
+      'react-native': Linter.Config
+      electron: Linter.Config
+      typescript: Linter.Config
+    }
+  }
+  export = _config
+}
+
+declare module 'eslint-plugin-mocha' {
+  import { Linter } from 'eslint'
+  const _config: {
+    rules: Linter.RulesRecord
+    configs: {
+      flat: {
+        recommended: Linter.FlatConfig
+        all: Linter.FlatConfig
+      }
+    }
+  }
+  export = _config
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,61 +1,70 @@
+import { FlatCompat } from '@eslint/eslintrc'
+import mochaPlugin from 'eslint-plugin-mocha'
 import { Linter } from 'eslint'
 
-export default {
-  extends: ['standard', 'plugin:import/recommended'],
-  settings: {
-    'import/resolver': {
-      node: true,
+const compat = new FlatCompat()
+
+const config: Linter.FlatConfig[] = [
+  ...compat.extends('standard'),
+  ...compat.extends('plugin:import/recommended'),
+  mochaPlugin.configs.flat.recommended,
+  {
+    settings: {
+      'import/resolver': {
+        node: true,
+      },
+    },
+    rules: {
+      'comma-dangle': ['error', 'always-multiline'],
+      'dot-notation': 'off',
+      'generator-star-spacing': ['error', 'after'],
+      'max-len': ['warn', 120],
+      'multiline-ternary': 'off',
+      'no-callback-literal': 'off',
+      'no-mixed-operators': 'off',
+      'no-use-before-define': 'off',
+      'no-return-assign': 'off',
+      'no-sequences': 'off',
+      'no-useless-escape': 'off',
+      'one-var': 'off',
+      'operator-linebreak': [
+        'error',
+        'after',
+        {
+          overrides: {
+            '?': 'before',
+            ':': 'before',
+          },
+        },
+      ],
+      'quotes': [
+        'error',
+        'single',
+        {
+          avoidEscape: true,
+          allowTemplateLiterals: true,
+        },
+      ],
+      'quote-props': ['error', 'consistent-as-needed'],
+      'valid-typeof': 'off',
+      'yield-star-spacing': ['error', 'after'],
+      'space-before-function-paren': 'off',
+      // Import plugin
+      'import/export': 'off',
+      'import/no-unresolved': 'error',
+      'import/order': [
+        'error',
+        {
+          'groups': ['builtin', 'external', 'internal', 'unknown', 'parent', 'sibling', 'index', 'object', 'type'],
+          'newlines-between': 'always',
+          'alphabetize': {
+            order: 'asc',
+            caseInsensitive: false,
+          },
+        },
+      ],
     },
   },
-  plugins: ['mocha'],
-  rules: {
-    'comma-dangle': ['error', 'always-multiline'],
-    'dot-notation': 'off',
-    'generator-star-spacing': ['error', 'after'],
-    'max-len': ['warn', 120],
-    'multiline-ternary': 'off',
-    'no-callback-literal': 'off',
-    'no-mixed-operators': 'off',
-    'no-use-before-define': 'off',
-    'no-return-assign': 'off',
-    'no-sequences': 'off',
-    'no-useless-escape': 'off',
-    'one-var': 'off',
-    'operator-linebreak': [
-      'error',
-      'after',
-      {
-        overrides: {
-          '?': 'before',
-          ':': 'before',
-        },
-      },
-    ],
-    'quotes': [
-      'error',
-      'single',
-      {
-        avoidEscape: true,
-        allowTemplateLiterals: true,
-      },
-    ],
-    'quote-props': ['error', 'consistent-as-needed'],
-    'valid-typeof': 'off',
-    'yield-star-spacing': ['error', 'after'],
-    'space-before-function-paren': 'off',
-    // Import plugin
-    'import/export': 'off',
-    'import/no-unresolved': 'error',
-    'import/order': [
-      'error',
-      {
-        'groups': ['builtin', 'external', 'internal', 'unknown', 'parent', 'sibling', 'index', 'object', 'type'],
-        'newlines-between': 'always',
-        'alphabetize': {
-          order: 'asc',
-          caseInsensitive: false,
-        },
-      },
-    ],
-  },
-} satisfies Linter.Config as Linter.Config
+]
+
+export default config

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,26 +1,33 @@
+import { FlatCompat } from '@eslint/eslintrc'
 import { Linter } from 'eslint'
+import globals from 'globals'
 
-export default {
-  extends: ['./index.js', 'plugin:n/recommended'],
-  env: {
-    node: true,
+import baseConfig from './index'
+
+const compat = new FlatCompat()
+const config: Linter.FlatConfig[] = [
+  ...baseConfig,
+  ...compat.extends('plugin:n/recommended'),
+  {
+    languageOptions: {
+      ecmaVersion: 2024,
+      globals: globals.node,
+    },
+    rules: {
+      'n/global-require': 'error',
+      'n/no-new-require': 'error',
+      'n/no-unpublished-import': 'off',
+      'n/no-unsupported-features/node-builtins': 'off',
+      'n/no-process-exit': 'off',
+      'n/prefer-global/buffer': 'error',
+      'n/prefer-global/console': 'error',
+      'n/prefer-global/process': 'error',
+      'n/prefer-global/text-decoder': 'error',
+      'n/prefer-global/text-encoder': 'error',
+      'n/prefer-global/url-search-params': 'error',
+      'n/prefer-global/url': 'error',
+    },
   },
-  parserOptions: {
-    ecmaVersion: 2024,
-  },
-  plugins: ['n'],
-  rules: {
-    'n/global-require': 'error',
-    'n/no-new-require': 'error',
-    'n/no-unpublished-import': 'off',
-    'n/no-unsupported-features/node-builtins': 'off',
-    'n/no-process-exit': 'off',
-    'n/prefer-global/buffer': 'error',
-    'n/prefer-global/console': 'error',
-    'n/prefer-global/process': 'error',
-    'n/prefer-global/text-decoder': 'error',
-    'n/prefer-global/text-encoder': 'error',
-    'n/prefer-global/url-search-params': 'error',
-    'n/prefer-global/url': 'error',
-  },
-} satisfies Linter.Config as Linter.Config
+]
+
+export default config

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -1,60 +1,77 @@
+import { FlatCompat } from '@eslint/eslintrc'
 import { Linter } from 'eslint'
+import tseslint from 'typescript-eslint'
 
-export default {
-  extends: ['./index.js', 'plugin:@typescript-eslint/recommended', 'plugin:import/typescript'],
-  parser: '@typescript-eslint/parser',
-  settings: {
-    'import/parsers': {
-      '@typescript-eslint/parser': ['.ts', '.tsx'],
-    },
-    'import/resolver': {
-      typescript: true,
+import baseConfig from './index'
+
+const compat = new FlatCompat()
+const config: Linter.FlatConfig[] = [
+  ...baseConfig,
+  ...(tseslint.configs.recommendedTypeChecked as Linter.FlatConfig[]),
+  {
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
   },
-  plugins: ['@typescript-eslint'],
-  rules: {
-    '@typescript-eslint/array-type': 'error',
-    'default-param-last': 'off',
-    '@typescript-eslint/default-param-last': 'error',
-    'func-call-spacing': 'off',
-    '@typescript-eslint/func-call-spacing': 'error',
-    'keyword-spacing': 'off',
-    '@typescript-eslint/keyword-spacing': 'error',
-    'no-redeclare': 'off',
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': [
-      'error',
-      {
-        args: 'none',
+  ...compat.extends('plugin:import/typescript'),
+  {
+    settings: {
+      'import/parsers': {
+        '@typescript-eslint/parser': ['.ts', '.tsx'],
       },
-    ],
-    'no-dupe-class-members': 'off',
-    '@typescript-eslint/no-dupe-class-members': 'error',
-    'no-inner-declarations': 'off',
-    'no-useless-constructor': 'off',
-    '@typescript-eslint/no-useless-constructor': 'warn',
-    'semi': 'off',
-    '@typescript-eslint/semi': ['error', 'never'],
-    '@typescript-eslint/member-delimiter-style': [
-      'error',
-      {
-        multiline: {
-          delimiter: 'none',
+      'import/resolver': {
+        typescript: true,
+      },
+    },
+    rules: {
+      '@typescript-eslint/array-type': 'error',
+      'default-param-last': 'off',
+      '@typescript-eslint/default-param-last': 'error',
+      'func-call-spacing': 'off',
+      '@typescript-eslint/func-call-spacing': 'error',
+      'keyword-spacing': 'off',
+      '@typescript-eslint/keyword-spacing': 'error',
+      'no-redeclare': 'off',
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          args: 'none',
         },
-        singleline: {
-          delimiter: 'semi',
+      ],
+      'no-dupe-class-members': 'off',
+      '@typescript-eslint/no-dupe-class-members': 'error',
+      'no-inner-declarations': 'off',
+      'no-useless-constructor': 'off',
+      '@typescript-eslint/no-useless-constructor': 'warn',
+      'semi': 'off',
+      '@typescript-eslint/semi': ['error', 'never'],
+      '@typescript-eslint/member-delimiter-style': [
+        'error',
+        {
+          multiline: {
+            delimiter: 'none',
+          },
+          singleline: {
+            delimiter: 'semi',
+          },
         },
-      },
-    ],
-    'space-before-function-paren': 'off',
-    '@typescript-eslint/space-before-function-paren': [
-      'error',
-      {
-        anonymous: 'always',
-        asyncArrow: 'always',
-        named: 'never',
-      },
-    ],
-    '@typescript-eslint/type-annotation-spacing': 'error',
+      ],
+      'space-before-function-paren': 'off',
+      '@typescript-eslint/space-before-function-paren': [
+        'error',
+        {
+          anonymous: 'always',
+          asyncArrow: 'always',
+          named: 'never',
+        },
+      ],
+      '@typescript-eslint/type-annotation-spacing': 'error',
+    },
   },
-} satisfies Linter.Config as Linter.Config
+]
+
+export default config


### PR DESCRIPTION
This is the final part of flat config support, but it is blocked by `eslint-plugin-import` which is not actually support ESLint v9 APIs (while the config itself could be translated by `FlatCompat` API from `@eslint/eslintrc` package). Although there is [an issue tracking the support in `eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import/issues/2948).